### PR TITLE
Remove official test support for Python2.x.

### DIFF
--- a/.github/workflows/build-and-test-rinchi_lib.yml
+++ b/.github/workflows/build-and-test-rinchi_lib.yml
@@ -24,8 +24,10 @@ jobs:
       # "! nm -D ..." tests that "INCHIGEN_Create" should NOT be present as symbol in .so file.
       run: cd src/rinchi_lib/ ; ! nm -D librinchi.so | grep INCHIGEN_Create
     
-    - name: rinchi_lib test - python2.
-      run: cd src/rinchi_lib/ ; python2 test.py > /tmp/py2-rinchi-lib-test-out.txt ; diff /tmp/py2-rinchi-lib-test-out.txt test.py.expected_output.txt
+    ## Python2 has been EOL for years, and has been removed from GitHub runner images.
+    ## Removing official RInChI support for Python2 as well.
+    ## - name: rinchi_lib test - python2.
+    ##  run: cd src/rinchi_lib/ ; python2 test.py > /tmp/py2-rinchi-lib-test-out.txt ; diff /tmp/py2-rinchi-lib-test-out.txt test.py.expected_output.txt
 
     - name: rinchi_lib test - python3.
       run: cd src/rinchi_lib/ ; python3 test.py > /tmp/py3-rinchi-lib-test-out.txt ; diff /tmp/py3-rinchi-lib-test-out.txt test.py.expected_output.txt


### PR DESCRIPTION
Merge in test changes to make rinchi_lib tests succeed.