### PR TITLE
refactor: use std::unique_ptr (C++11) instead of deprecated std::auto_ptr

### DIFF
--- a/src/example_apps/c_api_usage/Makefile-32bit
+++ b/src/example_apps/c_api_usage/Makefile-32bit
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m32 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m32 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m32 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../rinchi_lib -I../../lib -I../../parsers -I../../rinchi -I../../writers -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/example_apps/c_api_usage/Makefile-64bit
+++ b/src/example_apps/c_api_usage/Makefile-64bit
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m64 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m64 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../rinchi_lib -I../../lib -I../../parsers -I../../rinchi -I../../writers -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/example_apps/c_api_usage/Makefile-Mac
+++ b/src/example_apps/c_api_usage/Makefile-Mac
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m64 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m64 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../rinchi_lib -I../../lib -I../../parsers -I../../rinchi -I../../writers -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/example_apps/c_api_usage/Makefile-Raspberry
+++ b/src/example_apps/c_api_usage/Makefile-Raspberry
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        =  -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      =  -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      =  -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../rinchi_lib -I../../lib -I../../parsers -I../../rinchi -I../../writers -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/example_apps/c_api_usage/c_api_usage_qt.pro
+++ b/src/example_apps/c_api_usage/c_api_usage_qt.pro
@@ -9,6 +9,7 @@ TEMPLATE = app
 # InChI 1.0.6 required target definition.
 DEFINES  += TARGET_API_LIB
 QMAKE_CFLAGS += -ansi -DCOMPILE_ANSI_ONLY
+QMAKE_CXXFLAGS += -std=c++11
 
 DEPENDPATH += \
 	./../../rinchi_lib/ \

--- a/src/example_apps/rinchi_cmdline/Makefile-32bit
+++ b/src/example_apps/rinchi_cmdline/Makefile-32bit
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m32 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m32 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m32 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../lib -I../../parsers -I../../rinchi -I../../writers -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/example_apps/rinchi_cmdline/Makefile-64bit
+++ b/src/example_apps/rinchi_cmdline/Makefile-64bit
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m64 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m64 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../lib -I../../parsers -I../../rinchi -I../../writers -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/example_apps/rinchi_cmdline/Makefile-Mac
+++ b/src/example_apps/rinchi_cmdline/Makefile-Mac
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m64 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m64 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../lib -I../../parsers -I../../rinchi -I../../writers -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/example_apps/rinchi_cmdline/Makefile-Raspberry
+++ b/src/example_apps/rinchi_cmdline/Makefile-Raspberry
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        =  -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      =  -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      =  -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../lib -I../../parsers -I../../rinchi -I../../writers -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/example_apps/rinchi_cmdline/rinchi_cmdline_qt.pro
+++ b/src/example_apps/rinchi_cmdline/rinchi_cmdline_qt.pro
@@ -9,6 +9,7 @@ TEMPLATE = app
 # InChI 1.0.6 required target definition.
 DEFINES  += TARGET_API_LIB
 QMAKE_CFLAGS += -ansi -DCOMPILE_ANSI_ONLY
+QMAKE_CXXFLAGS += -std=c++11
 
 DEPENDPATH += \
 	./../../lib/ \

--- a/src/example_apps/rxn_from_molfiles/Makefile-32bit
+++ b/src/example_apps/rxn_from_molfiles/Makefile-32bit
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m32 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m32 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m32 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../lib -I../../parsers -I../../rinchi -I../../writers -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/example_apps/rxn_from_molfiles/Makefile-64bit
+++ b/src/example_apps/rxn_from_molfiles/Makefile-64bit
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m64 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m64 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../lib -I../../parsers -I../../rinchi -I../../writers -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/example_apps/rxn_from_molfiles/Makefile-Mac
+++ b/src/example_apps/rxn_from_molfiles/Makefile-Mac
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m64 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m64 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../lib -I../../parsers -I../../rinchi -I../../writers -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/example_apps/rxn_from_molfiles/Makefile-Raspberry
+++ b/src/example_apps/rxn_from_molfiles/Makefile-Raspberry
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        =  -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      =  -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      =  -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../lib -I../../parsers -I../../rinchi -I../../writers -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/example_apps/rxn_from_molfiles/rxn_from_molfiles_qt.pro
+++ b/src/example_apps/rxn_from_molfiles/rxn_from_molfiles_qt.pro
@@ -9,6 +9,7 @@ TEMPLATE = app
 # InChI 1.0.6 required target definition.
 DEFINES  += TARGET_API_LIB
 QMAKE_CFLAGS += -ansi -DCOMPILE_ANSI_ONLY
+QMAKE_CXXFLAGS += -std=c++11
 
 DEPENDPATH += \
 	./../../lib/ \

--- a/src/lib/rinchi_platform.h
+++ b/src/lib/rinchi_platform.h
@@ -44,7 +44,7 @@
 	#define ON_WINDOWS
 // TODO: Define MSVC appropriately. And use that condition directly above.
 	const char DIR_SEPARATOR = '\\';
-#elif defined(linux)
+#elif defined(__linux__)
 	#define ON_LINUX
 	const char DIR_SEPARATOR = '/';
 	#if defined(__i386__) || defined(__x86_64__)

--- a/src/parsers/rinchi_reader.cpp
+++ b/src/parsers/rinchi_reader.cpp
@@ -98,7 +98,7 @@ namespace rinchi {
 				// Validate and cleanup InChI input.
 				InChIGenerator().validate_inchi(inchi_string);
 
-				std::auto_ptr<ReactionComponent> cmp (new ReactionComponent());
+				std::unique_ptr<ReactionComponent> cmp (new ReactionComponent());
 				components.push_back(cmp.get());
 				ReactionComponent* tmp_cmp = cmp.release();
 				tmp_cmp->m_inchi_string = inchi_string;
@@ -389,7 +389,7 @@ void RInChIReader::split_into_reaction(const std::string& rinchi_string, const s
 
 		for (int i = 0; i < RINCHI_NUM_GROUPS; i++) {
 			for (int k = 0; k < rxn.m_nostruct_counts[i]; k++) {
-				std::auto_ptr<ReactionComponent> cmp (new ReactionComponent());
+				std::unique_ptr<ReactionComponent> cmp (new ReactionComponent());
 				rc_lists[i]->push_back(cmp.get());
 				ReactionComponent* tmp_cmp = cmp.release();
 				tmp_cmp->m_inchi_string  = NOSTRUCT_INCHI;

--- a/src/rinchi/rinchi_reaction.cpp
+++ b/src/rinchi/rinchi_reaction.cpp
@@ -157,7 +157,7 @@ namespace {
 
 	ReactionComponent* add_new_component_to_list(ReactionComponentList& list)
 	{
-		std::auto_ptr<ReactionComponent> cmp (new ReactionComponent());
+		std::unique_ptr<ReactionComponent> cmp (new ReactionComponent());
 		list.push_back(cmp.get());
 		return cmp.release();
 	}

--- a/src/rinchi_lib/Makefile-32bit
+++ b/src/rinchi_lib/Makefile-32bit
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m32 -pipe -ansi -DCOMPILE_ANSI_ONLY -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m32 -pipe -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m32 -pipe -std=c++11 -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../lib -I../parsers -I../rinchi -I../writers -I../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/rinchi_lib/Makefile-64bit
+++ b/src/rinchi_lib/Makefile-64bit
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m64 -pipe -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m64 -pipe -std=c++11 -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../lib -I../parsers -I../rinchi -I../writers -I../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/rinchi_lib/Makefile-Mac
+++ b/src/rinchi_lib/Makefile-Mac
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m64 -pipe -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m64 -pipe -std=c++11 -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../lib -I../parsers -I../rinchi -I../writers -I../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/rinchi_lib/Makefile-Mac-arm64-with-x86-Python
+++ b/src/rinchi_lib/Makefile-Mac-arm64-with-x86-Python
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -arch x86_64 -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -arch x86_64 -m64 -pipe -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -arch x86_64 -m64 -pipe -std=c++11 -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../lib -I../parsers -I../rinchi -I../writers -I../../INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/rinchi_lib/Makefile-Raspberry
+++ b/src/rinchi_lib/Makefile-Raspberry
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        =  -pipe -ansi -DCOMPILE_ANSI_ONLY -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      =  -pipe -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      =  -pipe -std=c++11 -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../lib -I../parsers -I../rinchi -I../writers -I../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/rinchi_lib/librinchi_qt.pro
+++ b/src/rinchi_lib/librinchi_qt.pro
@@ -11,6 +11,7 @@ TEMPLATE = lib
 # InChI 1.0.6 required target definition.
 DEFINES  += TARGET_API_LIB
 QMAKE_CFLAGS += -ansi -DCOMPILE_ANSI_ONLY
+QMAKE_CXXFLAGS += -std=c++11
 
 # Ensure that only explicitly exported functions are present in symbol table.
 QMAKE_CXXFLAGS += -fvisibility=hidden

--- a/src/rinchi_ora_cartridge/Makefile-32bit
+++ b/src/rinchi_ora_cartridge/Makefile-32bit
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m32 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m32 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m32 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../lib -I../parsers -I../rinchi -I../writers -I../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/rinchi_ora_cartridge/Makefile-64bit
+++ b/src/rinchi_ora_cartridge/Makefile-64bit
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m64 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m64 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../lib -I../parsers -I../rinchi -I../writers -I../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/rinchi_ora_cartridge/Makefile-Mac
+++ b/src/rinchi_ora_cartridge/Makefile-Mac
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        = -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m64 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m64 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../lib -I../parsers -I../rinchi -I../writers -I../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/rinchi_ora_cartridge/Makefile-Raspberry
+++ b/src/rinchi_ora_cartridge/Makefile-Raspberry
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DTARGET_API_LIB
 CFLAGS        =  -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      =  -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      =  -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../lib -I../parsers -I../rinchi -I../writers -I../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/rinchi_ora_cartridge/rinchi_ora_cartridge_qt.pro
+++ b/src/rinchi_ora_cartridge/rinchi_ora_cartridge_qt.pro
@@ -8,6 +8,7 @@ TEMPLATE = lib
 # InChI 1.0.6 required target definition.
 DEFINES  += TARGET_API_LIB
 QMAKE_CFLAGS += -ansi -DCOMPILE_ANSI_ONLY
+QMAKE_CXXFLAGS += -std=c++11
 
 DEPENDPATH += \
 	./../lib/ \

--- a/src/test/test_suite/Makefile-32bit
+++ b/src/test/test_suite/Makefile-32bit
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DIN_RINCHI_TEST_SUITE -DTARGET_API_LIB
 CFLAGS        = -m32 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m32 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m32 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../lib -I../../parsers -I../../rinchi -I../../writers -Itests -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/test/test_suite/Makefile-64bit
+++ b/src/test/test_suite/Makefile-64bit
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DIN_RINCHI_TEST_SUITE -DTARGET_API_LIB
 CFLAGS        = -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m64 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m64 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../lib -I../../parsers -I../../rinchi -I../../writers -Itests -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/test/test_suite/Makefile-Mac
+++ b/src/test/test_suite/Makefile-Mac
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DIN_RINCHI_TEST_SUITE -DTARGET_API_LIB
 CFLAGS        = -m64 -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      = -m64 -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      = -m64 -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../lib -I../../parsers -I../../rinchi -I../../writers -Itests -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/test/test_suite/Makefile-Raspberry
+++ b/src/test/test_suite/Makefile-Raspberry
@@ -14,7 +14,7 @@ CC            = gcc
 CXX           = g++
 DEFINES       = -DIN_RINCHI_TEST_SUITE -DTARGET_API_LIB
 CFLAGS        =  -pipe -ansi -DCOMPILE_ANSI_ONLY -O2 -Wall -W -fPIC $(DEFINES)
-CXXFLAGS      =  -pipe -O2 -Wall -W -fPIC $(DEFINES)
+CXXFLAGS      =  -pipe -std=c++11 -O2 -Wall -W -fPIC $(DEFINES)
 INCPATH       = -I. -I../../lib -I../../parsers -I../../rinchi -I../../writers -Itests -I../../../../InChI/INCHI-1-SRC/INCHI_BASE/src
 QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
 DEL_FILE      = rm -f

--- a/src/test/test_suite/rinchi_test_suite_qt.pro
+++ b/src/test/test_suite/rinchi_test_suite_qt.pro
@@ -7,6 +7,7 @@ DEFINES  += IN_RINCHI_TEST_SUITE
 # InChI 1.0.6 required target definition.
 DEFINES  += TARGET_API_LIB
 QMAKE_CFLAGS += -ansi -DCOMPILE_ANSI_ONLY
+QMAKE_CXXFLAGS += -std=c++11
 
 TEMPLATE = app
 


### PR DESCRIPTION
Also, linux detection logic is fixed because `linux` macro is NOT ALWAYS defined on Linux; use `__linux__` instead.

fix #25.