### PR TITLE
src/lib/rinchi_hashing: Correct comment about structure of 17-char hash

### DIFF
--- a/src/lib/rinchi_hashing.cpp
+++ b/src/lib/rinchi_hashing.cpp
@@ -142,7 +142,7 @@ std::string hash17char(const std::string& input)
 	result += base26_triplet_3(chksum);
 	result += base26_triplet_4(chksum);
 	result += base26_dublet_for_bits_56_to_64(chksum);
-	// chksum[8] = bits 65->...
+	// chksum[8] = bits 64.. (bit 64 is used twice)
 	result += base26_triplet_1(&chksum[8]);
 #ifdef RINCHI_DEBUG_OUTPUT_HASHING
 	std::cout << "[#17[" << input << "]#] => " << result << std::endl;
@@ -157,3 +157,4 @@ const std::string HASH_14_EMPTY_STRING = "UHFFFADPSCTJAU";
 const std::string HASH_17_EMPTY_STRING = "UHFFFADPSCTJAUYIS";
 
 } // end of namespace
+


### PR DESCRIPTION
The 17-char hash has the first 14 chars derived from bits 0-64 (that's 65 of them) and the last 3 derived from 64-77 (that's 14 of them). chksum[8] does not, in fact, start with bit 65.

* * * 
see also: https://github.com/IUPAC-InChI/InChI/discussions/193